### PR TITLE
use ubuntu 16.04 instead of 14.04

### DIFF
--- a/vpn.yml
+++ b/vpn.yml
@@ -4,9 +4,7 @@ executors:
   aws:
     machine:
       enabled: true
-      # The `classic:201808-01` image has a later version of the aws cli
-      # which is important for ECS deployments
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:201903-01
       docker_layer_caching: true
 
 commands:


### PR DESCRIPTION
change machine executor to one that is recommended by circle ci.

`circleci/classic:201808-01` image is using 5 years old release which got into EOL at 30th of April

but the main reason for that is to bump docker version to `18.09.3` which is bundled in `ubuntu-1604:201903-01`. that version of docker contains (most notable) build kit with the possibility to use ssh agent forwarding [release notes](https://docs.docker.com/develop/develop-images/build_enhancements/)